### PR TITLE
Update MakeGetRequest.xaml

### DIFF
--- a/Common/MakeGetRequest.xaml
+++ b/Common/MakeGetRequest.xaml
@@ -5,7 +5,7 @@
     <x:Property Name="in_Endpoint" Type="InArgument(x:String)" />
     <x:Property Name="out_ResultObject" Type="OutArgument(njl:JObject)" />
   </x:Members>
-  <sap:VirtualizedContainerService.HintSize>1140,1827</sap:VirtualizedContainerService.HintSize>
+  <sap:VirtualizedContainerService.HintSize>1260,1827</sap:VirtualizedContainerService.HintSize>
   <sap2010:WorkflowViewState.IdRef>ActivityBuilder_1</sap2010:WorkflowViewState.IdRef>
   <TextExpression.NamespacesForImplementation>
     <scg:List x:TypeArguments="x:String" Capacity="20">
@@ -125,7 +125,7 @@
               <Literal x:TypeArguments="x:String">get</Literal>
             </InArgument>
             <InArgument x:TypeArguments="x:String" x:Key="in_Endpoint">
-              <mva:VisualBasicValue x:TypeArguments="x:String" ExpressionText="String.Format(&quot;{0}$top={1]&amp;$skip={2}&quot;, in_Endpoint, in_Config(&quot;RequestBatchSize&quot;) ,RequestSkipSize)" />
+              <mva:VisualBasicValue x:TypeArguments="x:String" ExpressionText="String.Format(&quot;{0}&amp;$top={1}&amp;$skip={2}&quot;, in_Endpoint, in_Config(&quot;RequestBatchSize&quot;) ,RequestSkipSize)" />
             </InArgument>
             <InArgument x:TypeArguments="x:String" x:Key="in_Body" />
             <InArgument x:TypeArguments="x:Int64" x:Key="in_OUID">


### PR DESCRIPTION
fixed an argument under "Invoke MakeHTTPRequest Workflow" in MakeGetRequest.xaml.
Before: String.Format("{0}$skip={1}", in_Endpoint, RequestSkipSize)
After: String.Format("{0}$top={1]&$skip={2}", in_Endpoint, in_Config("RequestBatchSize") ,RequestSkipSize)

RequestSkipSize gets increased by RequestBatchSize in each iteration.

without this fix, the API tries to get all data regardless of skip parameter and may get timeout error depends on its volume.